### PR TITLE
refactor(ui): Remove documentUploadLimit quota displays and show uplo…

### DIFF
--- a/src/app/features/subscription/components/subscription-manage/subscription-manage.component.html
+++ b/src/app/features/subscription/components/subscription-manage/subscription-manage.component.html
@@ -133,9 +133,9 @@
               </svg>
             </div>
             <div class="stat-content">
-              <span class="stat-label">Documents</span>
+              <span class="stat-label">Documents Uploaded</span>
               <span class="stat-value">
-                {{ usage()?.documentsUsed || 0 }} / {{ formatLimit(usage()?.documentsLimit || 0) }}
+                {{ usage()?.documentsUsed || 0 }}
               </span>
             </div>
           </div>
@@ -196,25 +196,11 @@
             <!-- Documents -->
             <div class="usage-item">
               <div class="usage-header">
-                <span class="usage-label">Documents Processed</span>
+                <span class="usage-label">Documents Uploaded</span>
                 <span class="usage-values">
                   <strong>{{ usage()?.documentsUsed || 0 }}</strong>
-                  @if ((usage()?.documentsLimit || 0) > 0) {
-                    / {{ usage()?.documentsLimit }}
-                  } @else {
-                    <span class="unlimited">Unlimited</span>
-                  }
                 </span>
               </div>
-              @if ((usage()?.documentsLimit || 0) > 0) {
-                <div class="usage-bar">
-                  <div
-                    class="usage-fill"
-                    [class]="getUsageBarClass(documentsUsagePercent())"
-                    [style.width.%]="documentsUsagePercent()">
-                  </div>
-                </div>
-              }
             </div>
 
             <!-- OCR Pages -->

--- a/src/app/features/subscription/components/subscription-manage/subscription-manage.component.ts
+++ b/src/app/features/subscription/components/subscription-manage/subscription-manage.component.ts
@@ -36,7 +36,6 @@ export class SubscriptionManageComponent implements OnInit {
   readonly trialDaysRemaining = this.subState.trialDaysRemaining;
   readonly daysUntilRenewal = this.subState.daysUntilRenewal;
   readonly defaultPaymentMethod = this.subState.defaultPaymentMethod;
-  readonly documentsUsagePercent = this.subState.documentsUsagePercent;
   readonly ocrUsagePercent = this.subState.ocrUsagePercent;
   readonly storageUsagePercent = this.subState.storageUsagePercent;
 

--- a/src/app/features/subscription/models/subscription.model.ts
+++ b/src/app/features/subscription/models/subscription.model.ts
@@ -202,10 +202,11 @@ export interface StorageInfo {
   ocrPagesUsed: number;
   ocrPagesRemaining: number;
   ocrUnlimited: boolean;
-  documentUploadLimit: number;
   documentsUploaded: number;
-  documentsRemaining: number;
-  documentsUnlimited: boolean;
+  // Legacy document quota fields (deprecated by storage-based limits)
+  documentUploadLimit?: number;
+  documentsRemaining?: number;
+  documentsUnlimited?: boolean;
   subscriptionPlan: string;
   billingInterval: string;
   quotaResetDate: string | null;

--- a/src/app/features/subscription/pages/subscription-overview/subscription-overview.component.html
+++ b/src/app/features/subscription/pages/subscription-overview/subscription-overview.component.html
@@ -204,14 +204,10 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
           </svg>
           <span>
-            @if (storageInfo()?.documentQuotaExceeded && storageInfo()?.ocrQuotaExceeded) {
-              Document and OCR quota exceeded.
-            } @else if (storageInfo()?.documentQuotaExceeded) {
-              Document upload quota exceeded.
-            } @else if (storageInfo()?.ocrQuotaExceeded) {
+            @if (storageInfo()?.ocrQuotaExceeded) {
               OCR pages quota exceeded.
             } @else {
-              Quota exceeded.
+              Storage quota exceeded.
             }
             <a routerLink="/subscriptions/plans" class="alert-link">Upgrade your plan</a>
           </span>
@@ -227,25 +223,11 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
               </svg>
             </div>
-            <span class="usage-label">Documents</span>
-            @if (storageInfo()?.documentQuotaExceeded) {
-              <span class="usage-warn-dot"></span>
-            }
+            <span class="usage-label">Documents Uploaded</span>
           </div>
           <div class="usage-numbers">
             <span class="usage-value">{{ storageInfo()?.documentsUploaded || 0 }}</span>
-            @if (!storageInfo()?.documentsUnlimited && (storageInfo()?.documentUploadLimit || 0) > 0) {
-              <span class="usage-cap">/ {{ storageInfo()?.documentUploadLimit }}</span>
-            } @else if (storageInfo()?.documentsUnlimited) {
-              <span class="usage-unlimited">∞</span>
-            }
           </div>
-          @if (!storageInfo()?.documentsUnlimited && (storageInfo()?.documentUploadLimit || 0) > 0) {
-            <div class="progress-track">
-              <div class="progress-fill" [class]="getUsageBarClass(documentsUsagePercent())" [style.width.%]="documentsUsagePercent()"></div>
-            </div>
-            <span class="usage-footer">{{ storageInfo()?.documentsRemaining || 0 }} remaining</span>
-          }
         </div>
 
         <!-- OCR Pages -->

--- a/src/app/features/subscription/pages/subscription-overview/subscription-overview.component.ts
+++ b/src/app/features/subscription/pages/subscription-overview/subscription-overview.component.ts
@@ -33,7 +33,6 @@ export class SubscriptionOverviewComponent implements OnInit {
   readonly isCanceled = this.subState.isCanceled;
   readonly trialDaysRemaining = this.subState.trialDaysRemaining;
   readonly daysUntilRenewal = this.subState.daysUntilRenewal;
-  readonly documentsUsagePercent = this.subState.documentsUsagePercent;
   readonly ocrUsagePercent = this.subState.ocrUsagePercent;
   readonly storageUsagePercent = this.subState.storageUsagePercent;
 

--- a/src/app/features/subscription/services/subscription-state.service.ts
+++ b/src/app/features/subscription/services/subscription-state.service.ts
@@ -125,8 +125,8 @@ export class SubscriptionStateService {
   // Usage computations
   readonly documentsUsagePercent = computed(() => {
     const storage = this._storageInfo();
-    if (!storage || storage.documentsUnlimited || storage.documentUploadLimit <= 0) return 0;
-    return Math.min(100, Math.round((storage.documentsUploaded / storage.documentUploadLimit) * 100));
+    if (!storage || storage.unlimited || storage.storageLimit <= 0) return 0;
+    return Math.min(100, Math.round(storage.percentageUsed));
   });
 
   readonly ocrUsagePercent = computed(() => {
@@ -191,7 +191,7 @@ export class SubscriptionStateService {
             this._usage.update(u => u ? {
               ...u,
               documentsUsed: storage.documentsUploaded,
-              documentsLimit: storage.documentsUnlimited ? -1 : storage.documentUploadLimit,
+              documentsLimit: -1,
               ocrPagesUsed: storage.ocrPagesUsed,
               ocrPagesLimit: storage.ocrUnlimited ? -1 : storage.ocrPageLimit,
               storageUsedBytes: storage.storageUsed,

--- a/src/app/features/user/components/billing-settings/billing-settings.component.html
+++ b/src/app/features/user/components/billing-settings/billing-settings.component.html
@@ -162,9 +162,8 @@
       @if (storageInfo()) {
       <div class="usage-info">
         <div class="usage-item">
-          <span class="usage-label">Documents</span>
-          <span class="usage-value">{{ storageInfo()!.documentsUploaded }} / {{ storageInfo()!.documentsUnlimited ?
-            'Unlimited' : storageInfo()!.documentUploadLimit }}</span>
+          <span class="usage-label">Documents Uploaded</span>
+          <span class="usage-value">{{ storageInfo()!.documentsUploaded }}</span>
         </div>
         <div class="usage-item">
           <span class="usage-label">OCR Pages</span>

--- a/src/app/features/user/components/dashboard-overview/dashboard-overview.component.html
+++ b/src/app/features/user/components/dashboard-overview/dashboard-overview.component.html
@@ -328,29 +328,9 @@
             <!-- Documents Usage -->
             <div class="usage-item">
               <div class="usage-header">
-                <span class="usage-label">Documents</span>
-                @if (storageInfo()?.documentsUnlimited) {
-                  <span class="usage-value">{{ storageInfo()?.documentsUploaded || 0 }} uploaded</span>
-                } @else {
-                  <span class="usage-value">{{ storageInfo()?.documentsUploaded || 0 }} / {{ storageInfo()?.documentUploadLimit || 0 }}</span>
-                }
+                <span class="usage-label">Documents Uploaded</span>
+                <span class="usage-value">{{ storageInfo()?.documentsUploaded || 0 }}</span>
               </div>
-              @if (!storageInfo()?.documentsUnlimited) {
-                <div class="progress-bar">
-                  <div
-                    class="progress-fill documents"
-                    [class.critical]="storageInfo()?.documentQuotaExceeded"
-                    [style.width.%]="getDocumentUsagePercentage()">
-                  </div>
-                </div>
-              } @else {
-                <div class="unlimited-badge">
-                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"/>
-                  </svg>
-                  <span>Unlimited</span>
-                </div>
-              }
             </div>
 
             <!-- OCR Pages Usage -->

--- a/src/app/features/user/components/dashboard-overview/dashboard-overview.component.ts
+++ b/src/app/features/user/components/dashboard-overview/dashboard-overview.component.ts
@@ -185,16 +185,6 @@ export class DashboardOverviewComponent implements OnInit {
     return plan.split('_')[0].replace(/([A-Z])/g, ' $1').trim();
   }
 
-  /**
-   * Calculate document usage percentage
-   */
-  getDocumentUsagePercentage(): number {
-    const storage = this.storageInfo();
-    if (!storage || storage.documentsUnlimited || storage.documentUploadLimit === 0) {
-      return 0;
-    }
-    return Math.round((storage.documentsUploaded / storage.documentUploadLimit) * 100);
-  }
 
   /**
    * Format bytes to human-readable string

--- a/src/app/features/user/components/storage-usage/storage-usage.component.html
+++ b/src/app/features/user/components/storage-usage/storage-usage.component.html
@@ -170,61 +170,16 @@
             </svg>
           </div>
           <div class="card-title-group">
-            <h3 class="card-title">Document Uploads</h3>
-            <span class="card-subtitle">Monthly upload quota</span>
+            <h3 class="card-title">Documents Uploaded</h3>
+            <span class="card-subtitle">Total documents uploaded</span>
           </div>
         </div>
 
         <div class="usage-stats">
           <div class="usage-main">
-            @if (info.documentsUnlimited) {
-              <span class="usage-value">{{ info.documentsUploaded }}</span>
-              <span class="usage-unlimited">Unlimited</span>
-            } @else {
-              <span class="usage-value">{{ info.documentsUploaded }}</span>
-              <span class="usage-separator">/</span>
-              <span class="usage-limit">{{ info.documentUploadLimit }}</span>
-            }
+            <span class="usage-value">{{ info.documentsUploaded }}</span>
           </div>
-          @if (!info.documentsUnlimited) {
-            <div class="usage-percentage" [class.exceeded]="info.documentQuotaExceeded">
-              {{ documentsPercentage() }}%
-            </div>
-          }
         </div>
-
-        @if (!info.documentsUnlimited) {
-          <div class="progress-container">
-            <div class="progress-bar">
-              <div
-                class="progress-fill"
-                [class]="getProgressBarClass(documentsPercentage(), info.documentQuotaExceeded)"
-                [style.width.%]="documentsPercentage()">
-              </div>
-            </div>
-          </div>
-          <div class="usage-details">
-            <span class="detail-item">
-              <span class="detail-label">Remaining:</span>
-              <span class="detail-value">{{ info.documentsRemaining }} documents</span>
-            </span>
-          </div>
-          @if (info.documentQuotaExceeded) {
-            <div class="quota-warning">
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
-              </svg>
-              <span>You've exceeded your monthly document upload limit</span>
-            </div>
-          }
-        } @else {
-          <div class="unlimited-badge">
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"/>
-            </svg>
-            <span>Unlimited Uploads</span>
-          </div>
-        }
       </div>
 
       <!-- OCR Pages Card -->

--- a/src/app/features/user/components/storage-usage/storage-usage.component.ts
+++ b/src/app/features/user/components/storage-usage/storage-usage.component.ts
@@ -26,11 +26,6 @@ export class StorageUsageComponent implements OnInit {
     return Math.min(info.percentageUsed, 100);
   });
 
-  readonly documentsPercentage = computed(() => {
-    const info = this.storageInfo();
-    if (!info || info.documentUploadLimit === 0 || info.documentsUnlimited) return 0;
-    return Math.min(Math.round((info.documentsUploaded / info.documentUploadLimit) * 100), 100);
-  });
 
   readonly ocrPercentage = computed(() => {
     const info = this.storageInfo();

--- a/src/app/features/user/models/user.model.ts
+++ b/src/app/features/user/models/user.model.ts
@@ -57,10 +57,11 @@ export interface StorageInfo {
   ocrPagesUsed: number;
   ocrPagesRemaining: number;
   ocrUnlimited: boolean;
-  documentUploadLimit: number;
   documentsUploaded: number;
-  documentsRemaining: number;
-  documentsUnlimited: boolean;
+  // Legacy document quota fields (deprecated by storage-based limits)
+  documentUploadLimit?: number;
+  documentsRemaining?: number;
+  documentsUnlimited?: boolean;
   subscriptionPlan: string;
   billingInterval: string;
   quotaResetDate: string;
@@ -76,9 +77,9 @@ export interface DashboardStats {
   totalDocuments: number;
   documentsThisMonth: number;
   documentsUploaded: number;
-  documentUploadLimit: number;
-  documentsRemaining: number;
-  documentsUnlimited: boolean;
+  documentUploadLimit?: number;
+  documentsRemaining?: number;
+  documentsUnlimited?: boolean;
   documentQuotaExceeded: boolean;
 
   // OCR

--- a/src/app/features/user/services/user-state.service.ts
+++ b/src/app/features/user/services/user-state.service.ts
@@ -111,10 +111,8 @@ export class UserStateService {
         title: 'Documents',
         value: `${storage.documentsUploaded}`,
         icon: 'document',
-        color: storage.documentQuotaExceeded ? 'red' : 'blue',
-        subtitle: storage.documentsUnlimited
-          ? 'Unlimited'
-          : `${storage.documentsRemaining} remaining of ${storage.documentUploadLimit}`,
+        color: 'blue',
+        subtitle: 'Uploaded documents',
         link: '/documents'
       },
       {


### PR DESCRIPTION
…aded count only

- replace document quota bars/caps with storage-based usage where applicable
- keep documentsUploaded visible across dashboard, storage, billing, and subscription pages
- make legacy document quota fields optional in storage models for compatibility